### PR TITLE
Add a Proxy property to use when downloading the driver

### DIFF
--- a/WebDriverManager.Tests/BinaryServiceTests.cs
+++ b/WebDriverManager.Tests/BinaryServiceTests.cs
@@ -15,7 +15,7 @@ namespace WebDriverManager.Tests
             const string url = "https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip";
             var destination = FileHelper.GetZipDestination(url);
             FileHelper.CreateDestinationDirectory(destination);
-            var result = DownloadZip(url, destination);
+            var result = DownloadZip(url, destination, WebRequest.DefaultWebProxy);
             Assert.NotEmpty(result);
             Assert.True(File.Exists(result));
         }
@@ -55,10 +55,9 @@ namespace WebDriverManager.Tests
         {
             const string url = "https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip";
             WebProxyStub proxy = new WebProxyStub();
-            Proxy = proxy;
             var destination = FileHelper.GetZipDestination(url);
             FileHelper.CreateDestinationDirectory(destination);
-            var result = DownloadZip(url, destination);
+            var result = DownloadZip(url, destination, proxy);
             Assert.Equal(new Uri(url), proxy.RequestedUri);
             Assert.NotEmpty(result);
             Assert.True(File.Exists(result));

--- a/WebDriverManager.Tests/BinaryServiceTests.cs
+++ b/WebDriverManager.Tests/BinaryServiceTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Net;
 using WebDriverManager.Helpers;
 using WebDriverManager.Services.Impl;
 using Xunit;
@@ -46,6 +48,32 @@ namespace WebDriverManager.Tests
             Assert.True(File.Exists(zipPath));
             RemoveZip(zipPath);
             Assert.False(File.Exists(zipPath));
+        }
+
+        [Fact]
+        public void DownloadZipFileWithProxy()
+        {
+            const string url = "https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip";
+            WebProxyStub proxy = new WebProxyStub();
+            Proxy = proxy;
+            var destination = FileHelper.GetZipDestination(url);
+            FileHelper.CreateDestinationDirectory(destination);
+            var result = DownloadZip(url, destination);
+            Assert.Equal(new Uri(url), proxy.RequestedUri);
+            Assert.NotEmpty(result);
+            Assert.True(File.Exists(result));
+        }
+
+        public class WebProxyStub : IWebProxy
+        {
+            public Uri RequestedUri { get; set; }
+            public ICredentials Credentials { get; set; }
+            public Uri GetProxy(Uri destination) => new Uri("http://localhost");
+            public bool IsBypassed(Uri host)
+            {
+                RequestedUri = host;
+                return true;
+            }
         }
     }
 }

--- a/WebDriverManager/DriverManager.cs
+++ b/WebDriverManager/DriverManager.cs
@@ -29,14 +29,24 @@ namespace WebDriverManager
 
         public void SetUpDriver(string url, string binaryPath, string binaryName)
         {
+            IWebProxy proxy = WebRequest.DefaultWebProxy;
+            SetUpDriver(url, binaryPath, binaryName, proxy);
+        }
+        public void SetUpDriver(string url, string binaryPath, string binaryName, IWebProxy proxy)
+        {
             var zipPath = FileHelper.GetZipDestination(url);
-            _binaryService.Proxy = Proxy;
-            binaryPath = _binaryService.SetupBinary(url, zipPath, binaryPath, binaryName);
+            binaryPath = _binaryService.SetupBinary(url, zipPath, binaryPath, binaryName, proxy);
             _variableService.SetupVariable(binaryPath);
         }
 
         public void SetUpDriver(IDriverConfig config, string version = "Latest",
             Architecture architecture = Architecture.Auto)
+        {
+            IWebProxy proxy = WebRequest.DefaultWebProxy;
+            SetUpDriver(config, proxy, version, architecture);
+        }
+        public void SetUpDriver(IDriverConfig config, IWebProxy proxy, string version = "Latest",
+                Architecture architecture = Architecture.Auto)
         {
             lock (_object)
             {
@@ -48,7 +58,7 @@ namespace WebDriverManager
                 url = UrlHelper.BuildUrl(url, version);
                 var binaryPath = FileHelper.GetBinDestination(config.GetName(), version, architecture,
                     config.GetBinaryName());
-                SetUpDriver(url, binaryPath, config.GetBinaryName());
+                SetUpDriver(url, binaryPath, config.GetBinaryName(), proxy);
             }
         }
     }

--- a/WebDriverManager/DriverManager.cs
+++ b/WebDriverManager/DriverManager.cs
@@ -1,4 +1,5 @@
-﻿using WebDriverManager.DriverConfigs;
+using System.Net;
+using WebDriverManager.DriverConfigs;
 using WebDriverManager.Helpers;
 using WebDriverManager.Services;
 using WebDriverManager.Services.Impl;
@@ -24,9 +25,12 @@ namespace WebDriverManager
             _variableService = variableService;
         }
 
+        public IWebProxy Proxy { get; set; }
+
         public void SetUpDriver(string url, string binaryPath, string binaryName)
         {
             var zipPath = FileHelper.GetZipDestination(url);
+            _binaryService.Proxy = Proxy;
             binaryPath = _binaryService.SetupBinary(url, zipPath, binaryPath, binaryName);
             _variableService.SetupVariable(binaryPath);
         }

--- a/WebDriverManager/Services/IBinaryService.cs
+++ b/WebDriverManager/Services/IBinaryService.cs
@@ -1,7 +1,10 @@
-﻿namespace WebDriverManager.Services
+using System.Net;
+
+namespace WebDriverManager.Services
 {
     public interface IBinaryService
     {
         string SetupBinary(string url, string zipDestination, string binDestination, string binaryName);
+        IWebProxy Proxy { get; set; }
     }
 }

--- a/WebDriverManager/Services/IBinaryService.cs
+++ b/WebDriverManager/Services/IBinaryService.cs
@@ -4,7 +4,6 @@ namespace WebDriverManager.Services
 {
     public interface IBinaryService
     {
-        string SetupBinary(string url, string zipDestination, string binDestination, string binaryName);
-        IWebProxy Proxy { get; set; }
+        string SetupBinary(string url, string zipDestination, string binDestination, string binaryName, IWebProxy proxy);
     }
 }

--- a/WebDriverManager/Services/Impl/BinaryService.cs
+++ b/WebDriverManager/Services/Impl/BinaryService.cs
@@ -12,6 +12,8 @@ namespace WebDriverManager.Services.Impl
 {
     public class BinaryService : IBinaryService
     {
+        public IWebProxy Proxy { get; set; }
+
         public string SetupBinary(string url, string zipDestination, string binDestination, string binaryName)
         {
             if (File.Exists(binDestination)) return binDestination;
@@ -46,7 +48,7 @@ namespace WebDriverManager.Services.Impl
         protected string DownloadZip(string url, string destination)
         {
             if (File.Exists(destination)) return destination;
-            using (var webClient = new WebClient())
+            using (var webClient = new WebClient() { Proxy = Proxy })
             {
                 webClient.DownloadFile(new Uri(url), destination);
             }

--- a/WebDriverManager/Services/Impl/BinaryService.cs
+++ b/WebDriverManager/Services/Impl/BinaryService.cs
@@ -12,13 +12,11 @@ namespace WebDriverManager.Services.Impl
 {
     public class BinaryService : IBinaryService
     {
-        public IWebProxy Proxy { get; set; }
-
-        public string SetupBinary(string url, string zipDestination, string binDestination, string binaryName)
+        public string SetupBinary(string url, string zipDestination, string binDestination, string binaryName, IWebProxy proxy)
         {
             if (File.Exists(binDestination)) return binDestination;
             FileHelper.CreateDestinationDirectory(zipDestination);
-            zipDestination = DownloadZip(url, zipDestination);
+            zipDestination = DownloadZip(url, zipDestination, proxy);
             FileHelper.CreateDestinationDirectory(binDestination);
 
             if (zipDestination.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
@@ -45,10 +43,10 @@ namespace WebDriverManager.Services.Impl
             return binDestination;
         }
 
-        protected string DownloadZip(string url, string destination)
+        protected string DownloadZip(string url, string destination, IWebProxy proxy)
         {
             if (File.Exists(destination)) return destination;
-            using (var webClient = new WebClient() { Proxy = Proxy })
+            using (var webClient = new WebClient() { Proxy = proxy })
             {
                 webClient.DownloadFile(new Uri(url), destination);
             }


### PR DESCRIPTION
When accessing the Internet, an error occurred when downloading WebDriver in an environment where you had to always go through the Proxy.
Therefore, I added a Proxy property so that it can be downloaded even in an environment where Proxy is required.