### PR TITLE
Support thread and process concurrency

### DIFF
--- a/WebDriverManager/Services/IBinaryService.cs
+++ b/WebDriverManager/Services/IBinaryService.cs
@@ -1,7 +1,12 @@
-﻿namespace WebDriverManager.Services
+using System;
+
+namespace WebDriverManager.Services
 {
     public interface IBinaryService
     {
+        [Obsolete("binaryName parameter is redundant, use SetupBinary(url, zipDestination, binDestination)")]
         string SetupBinary(string url, string zipDestination, string binDestination, string binaryName);
+
+        string SetupBinary(string url, string zipDestination, string binDestination);
     }
 }


### PR DESCRIPTION
Improve existing pessimistic thread concurrency by locking consistently
across all DriverManager.SetUpDriver() entry points.

Teach BinaryService.SetupBinary() optimistic process concurrency by
doing all preparation (driver download, extraction, etc.) in the
isolated temp directory before cutting over to the final output
directory with an atomic directory rename, tolerating the "already
exists" error that occurs if another process races and wins.

One of the existing SetUpDriver() overloads has a redundant third
parameter.  Mark it [Obsolete] and provide a new overload without the
redundant parameter.

Eliminate a couple of redundant return values.

+semver:feature