### PR TITLE
Fix for error "Source and destination path must have identical roots. Move will not work across volumes"

### DIFF
--- a/WebDriverManager/Services/Impl/BinaryService.cs
+++ b/WebDriverManager/Services/Impl/BinaryService.cs
@@ -87,12 +87,12 @@ namespace WebDriverManager.Services.Impl
                 string[] files = Directory.GetFiles(stagingDir);
 
                 // Copy the files and overwrite destination files if they already exist.
-                foreach (string s in files)
+                foreach (string file in files)
                 {
                     // Use static Path methods to extract only the file name from the path.
-                    var fileName = Path.GetFileName(s);
+                    var fileName = Path.GetFileName(file);
                     var destFile = Path.Combine(binaryDir, fileName);
-                    File.Copy(s, destFile, true);
+                    File.Copy(file, destFile, true);
                 }
             }
             catch (Exception ex)

--- a/WebDriverManager/Services/Impl/BinaryService.cs
+++ b/WebDriverManager/Services/Impl/BinaryService.cs
@@ -71,10 +71,9 @@ namespace WebDriverManager.Services.Impl
 #endif
 
             //
-            // Create the destination parent directory if it doesn't exist
+            // Create the destination directory if it doesn't exist
             //
-            var binaryParentDir = Path.GetDirectoryName(binaryDir);
-            Directory.CreateDirectory(binaryParentDir);
+            Directory.CreateDirectory(binaryDir);
 
             //
             // Atomically rename the staging directory to the destination directory
@@ -85,7 +84,16 @@ namespace WebDriverManager.Services.Impl
             Exception renameException = null;
             try
             {
-                Directory.Move(stagingDir, binaryDir);
+                string[] files = Directory.GetFiles(stagingDir);
+
+                // Copy the files and overwrite destination files if they already exist.
+                foreach (string s in files)
+                {
+                    // Use static Path methods to extract only the file name from the path.
+                    var fileName = Path.GetFileName(s);
+                    var destFile = Path.Combine(binaryDir, fileName);
+                    File.Copy(s, destFile, true);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Closes #145 

Fix for error "Source and destination path must have identical roots. Move will not work across volumes"

https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.move?redirectedfrom=MSDN&view=net-5.0#exceptions

