### PR TITLE
Improve latest version detection for Firefox and Opera

### DIFF
--- a/WebDriverManager/DriverConfigs/Impl/FirefoxConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/FirefoxConfig.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Linq;
-using System.Net;
 using System.Runtime.InteropServices;
-using AngleSharp.Html.Parser;
+using WebDriverManager.Helpers;
 using Architecture = WebDriverManager.Helpers.Architecture;
 
 namespace WebDriverManager.DriverConfigs.Impl
@@ -37,18 +35,7 @@ namespace WebDriverManager.DriverConfigs.Impl
 
         public virtual string GetLatestVersion()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            using (var client = new WebClient())
-            {
-                var htmlCode = client.DownloadString("https://github.com/mozilla/geckodriver/releases");
-                var parser = new HtmlParser();
-                var document = parser.ParseDocument(htmlCode);
-                var version = document.QuerySelectorAll("[class='Link--primary']")
-                    .Select(element => element.TextContent)
-                    .FirstOrDefault()
-                    ?.Replace("v", "");
-                return version;
-            }
+            return GitHubHelper.GetLatestReleaseName("mozilla", "geckodriver");
         }
 
         public virtual string GetMatchingBrowserVersion()

--- a/WebDriverManager/DriverConfigs/Impl/OperaConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/OperaConfig.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
-using System.Net;
-using AngleSharp.Html.Parser;
+using WebDriverManager.Helpers;
 
 namespace WebDriverManager.DriverConfigs.Impl
 {
@@ -31,17 +29,7 @@ namespace WebDriverManager.DriverConfigs.Impl
 
         public virtual string GetLatestVersion()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            using (var client = new WebClient())
-            {
-                var htmlCode = client.DownloadString("https://github.com/operasoftware/operachromiumdriver/releases");
-                var parser = new HtmlParser();
-                var document = parser.ParseDocument(htmlCode);
-                var version = document.QuerySelectorAll("[class='Link--primary']")
-                    .Select(element => element.TextContent)
-                    .FirstOrDefault();
-                return version;
-            }
+            return GitHubHelper.GetLatestReleaseName("operasoftware", "operachromiumdriver");
         }
 
         public virtual string GetMatchingBrowserVersion()

--- a/WebDriverManager/Helpers/GitHubHelper.cs
+++ b/WebDriverManager/Helpers/GitHubHelper.cs
@@ -7,9 +7,14 @@ namespace WebDriverManager.Helpers
 {
     internal static class GitHubHelper
     {
+        private static readonly string _assemblyUserAgent;
+
         static GitHubHelper()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            var version = typeof(GitHubHelper).Assembly.GetName().Version;
+            _assemblyUserAgent = $"WebDriverManager.Net/{version}";
         }
 
         public static string GetLatestReleaseName(string owner, string repo)
@@ -27,8 +32,7 @@ namespace WebDriverManager.Helpers
 
                 // All API requests MUST include a valid User-Agent header. Requests with no User-Agent header will be rejected.
                 // <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required>
-                // TODO: Detect current package version.
-                client.Headers.Add(HttpRequestHeader.UserAgent, "2.12.2");
+                client.Headers.Add(HttpRequestHeader.UserAgent, _assemblyUserAgent);
 
                 json = client.DownloadString($"https://api.github.com/repos/{owner}/{repo}/releases/latest");
             }

--- a/WebDriverManager/Helpers/GitHubHelper.cs
+++ b/WebDriverManager/Helpers/GitHubHelper.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using System.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace WebDriverManager.Helpers
+{
+    internal static class GitHubHelper
+    {
+        static GitHubHelper()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+        }
+
+        public static string GetLatestReleaseName(string owner, string repo)
+        {
+            Debug.Assert(string.IsNullOrWhiteSpace(owner) is false);
+            Debug.Assert(string.IsNullOrWhiteSpace(repo) is false);
+
+            string json;
+
+            using (var client = new WebClient())
+            {
+                // Use the specific version of the API for stability.
+                // <https://docs.github.com/en/rest/overview/media-types>
+                client.Headers.Add(HttpRequestHeader.Accept, "application/vnd.github.v3+json");
+
+                // All API requests MUST include a valid User-Agent header. Requests with no User-Agent header will be rejected.
+                // <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required>
+                // TODO: Detect current package version.
+                client.Headers.Add(HttpRequestHeader.UserAgent, "2.12.2");
+
+                json = client.DownloadString($"https://api.github.com/repos/{owner}/{repo}/releases/latest");
+            }
+
+            var releaseObject = JsonConvert.DeserializeObject<JObject>(json);
+
+            return releaseObject.Value<string>("name");
+        }
+    }
+}

--- a/WebDriverManager/WebDriverManager.csproj
+++ b/WebDriverManager/WebDriverManager.csproj
@@ -4,7 +4,7 @@
 
         <TargetFrameworks>netstandard2.0;netstandard2.1;net46</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.12.2</PackageVersion>
+        <Version>2.12.2</Version>
         <Title>WebDriverManager.Net</Title>
         <Description>Automatic Selenium WebDriver binaries management for .Net</Description>
         <Copyright>© 2016-2021, Aliaksandr Rasolka. All Rights Reserved.</Copyright>

--- a/WebDriverManager/WebDriverManager.csproj
+++ b/WebDriverManager/WebDriverManager.csproj
@@ -18,8 +18,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="0.16.1" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
     </ItemGroup>
 


### PR DESCRIPTION
Now instead of parsing HTML of the GitHub releases page we parse JSON of the latest available release we fetch using GitHub API, which is faster and should be much more reliable.

This is actually a breaking change for package consumers since we drop `AngleSharp` dependency in favor of `Newtonsoft.Json`.