### PR TITLE
GetMatchingBrowserVersion for other browsers

### DIFF
--- a/WebDriverManager.Tests/FirefoxConfigTests.cs
+++ b/WebDriverManager.Tests/FirefoxConfigTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.RegularExpressions;
 using WebDriverManager.DriverConfigs.Impl;
 using Xunit;
@@ -26,7 +25,10 @@ namespace WebDriverManager.Tests
         [Fact]
         public void GetMatchingBrowserVersionTest()
         {
-            Assert.Throws<NotImplementedException>(GetMatchingBrowserVersion);
+            var version = GetLatestVersion();
+            var regex = new Regex(@"^\d+\.\d+\.\d+$");
+            Assert.NotEmpty(version);
+            Assert.Matches(regex, version);
         }
     }
 }

--- a/WebDriverManager.Tests/FirefoxConfigTests.cs
+++ b/WebDriverManager.Tests/FirefoxConfigTests.cs
@@ -27,8 +27,9 @@ namespace WebDriverManager.Tests
         public void GetMatchingBrowserVersionTest()
         {
             var version = GetMatchingBrowserVersion();
+            var regex = new Regex(@"^\d+\.\d+(\.\d+)?$");
             Assert.NotEmpty(version);
-            Version.Parse(version);
+            Assert.Matches(regex, version);
         }
     }
 }

--- a/WebDriverManager.Tests/FirefoxConfigTests.cs
+++ b/WebDriverManager.Tests/FirefoxConfigTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using WebDriverManager.DriverConfigs.Impl;
 using Xunit;
@@ -25,10 +26,9 @@ namespace WebDriverManager.Tests
         [Fact]
         public void GetMatchingBrowserVersionTest()
         {
-            var version = GetLatestVersion();
-            var regex = new Regex(@"^\d+\.\d+\.\d+$");
+            var version = GetMatchingBrowserVersion();
             Assert.NotEmpty(version);
-            Assert.Matches(regex, version);
+            Version.Parse(version);
         }
     }
 }

--- a/WebDriverManager.Tests/InternetExplorerConfigTests.cs
+++ b/WebDriverManager.Tests/InternetExplorerConfigTests.cs
@@ -26,7 +26,10 @@ namespace WebDriverManager.Tests
         [Fact]
         public void GetMatchingBrowserVersionTest()
         {
-            Assert.Throws<NotImplementedException>(GetMatchingBrowserVersion);
+            var version = GetMatchingBrowserVersion();
+            var regex = new Regex(@"^\d+\.\d+\.\d+(\.\d+)?$");
+            Assert.NotEmpty(version);
+            Assert.Matches(regex, version);
         }
     }
 }

--- a/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
@@ -102,14 +102,9 @@ namespace WebDriverManager.DriverConfigs.Impl
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                try
-                {
-                    return RegistryHelper.GetInstalledBrowserVersionLinux("google-chrome", "--product-version");
-                }
-                catch
-                {
-                    return RegistryHelper.GetInstalledBrowserVersionLinux("chromium", "--version");
-                }
+                return RegistryHelper.GetInstalledBrowserVersionLinux(
+                    "google-chrome", "--product-version",
+                    "chromium", "--version");
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
@@ -102,7 +102,14 @@ namespace WebDriverManager.DriverConfigs.Impl
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return RegistryHelper.GetInstalledBrowserVersionLinux("google-chrome", "--product-version");
+                try
+                {
+                    return RegistryHelper.GetInstalledBrowserVersionLinux("google-chrome", "--product-version");
+                }
+                catch
+                {
+                    return RegistryHelper.GetInstalledBrowserVersionLinux("chromium", "--version");
+                }
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/WebDriverManager/DriverConfigs/Impl/FirefoxConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/FirefoxConfig.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using AngleSharp.Html.Parser;
+using WebDriverManager.Helpers;
 using Architecture = WebDriverManager.Helpers.Architecture;
 
 namespace WebDriverManager.DriverConfigs.Impl
@@ -53,7 +54,26 @@ namespace WebDriverManager.DriverConfigs.Impl
 
         public virtual string GetMatchingBrowserVersion()
         {
-            throw new NotImplementedException();
+#if NETSTANDARD
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return RegistryHelper.GetInstalledBrowserVersionOsx("Firefox", "--version");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return RegistryHelper.GetInstalledBrowserVersionLinux("firefox", "--version");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return RegistryHelper.GetInstalledBrowserVersionWin("firefox.exe");
+            }
+
+            throw new PlatformNotSupportedException("Your operating system is not supported");
+#else
+            return RegistryHelper.GetInstalledBrowserVersionWin("chrome.exe");
+#endif
         }
 
         private static string GetUrl(Architecture architecture)

--- a/WebDriverManager/DriverConfigs/Impl/FirefoxConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/FirefoxConfig.cs
@@ -72,7 +72,7 @@ namespace WebDriverManager.DriverConfigs.Impl
 
             throw new PlatformNotSupportedException("Your operating system is not supported");
 #else
-            return RegistryHelper.GetInstalledBrowserVersionWin("chrome.exe");
+            return RegistryHelper.GetInstalledBrowserVersionWin("firefox.exe");
 #endif
         }
 

--- a/WebDriverManager/DriverConfigs/Impl/InternetExplorerConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/InternetExplorerConfig.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+using WebDriverManager.Helpers;
 
 namespace WebDriverManager.DriverConfigs.Impl
 {
@@ -31,7 +34,17 @@ namespace WebDriverManager.DriverConfigs.Impl
 
         public virtual string GetMatchingBrowserVersion()
         {
-            throw new NotImplementedException();
+#if NETSTANDARD
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException("Your operating system is not supported");
+            }
+#endif
+
+            return (string)Registry.GetValue(
+                @"HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer",
+                "svcVersion",
+                "Latest");
         }
     }
 }

--- a/WebDriverManager/DriverConfigs/Impl/InternetExplorerConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/InternetExplorerConfig.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
-using WebDriverManager.Helpers;
 
 namespace WebDriverManager.DriverConfigs.Impl
 {

--- a/WebDriverManager/Helpers/VersionHelper.cs
+++ b/WebDriverManager/Helpers/VersionHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace WebDriverManager.Helpers
@@ -49,7 +50,9 @@ namespace WebDriverManager.Helpers
                 throw new Exception(error);
             }
 
-            return output;
+            // Tries to pick out just the version string, e.g. from "Chromium 101.0.4951.64 Arch Linux" pick
+            // "101.0.4951.64" and from "Mozilla Firefox 100.0" pick "100.0".
+            return output.Split().LastOrDefault(word => Version.TryParse(word, out _)) ?? output;
         }
     }
 }


### PR DESCRIPTION
I have added the missing `IDriverConfig.GetMatchingBrowserVersionTest` implementations for Firefox and IE. Also I made ChromeConfig use `chromium` as a fallback on Linux (it seems like chromedriver happily calls `chromium` if only that's available, so it was only a problem for the version getter logic). I have verified that they get the desired output on Windows 10 and Arch Linux.

This is based on my current project in improving Lombiq UI Testing Toolkit [here](https://github.com/Lombiq/UI-Testing-Toolbox/blob/ecc69685cd434fdbb9c4235c598890241739224b/Lombiq.Tests.UI/Services/WebDriverFactory.cs#L187)