### PR TITLE
Add ability to set download directory for webDrivers ( #167 )

### DIFF
--- a/WebDriverManager/DriverManager.cs
+++ b/WebDriverManager/DriverManager.cs
@@ -14,15 +14,16 @@ namespace WebDriverManager
 
         private IBinaryService _binaryService;
         private readonly IVariableService _variableService;
-        private string _downloadDirectory = Directory.GetCurrentDirectory();
+        private string _downloadDirectory;
 
         public DriverManager()
         {
             _binaryService = new BinaryService();
             _variableService = new VariableService();
+            _downloadDirectory = Directory.GetCurrentDirectory();
         }
 
-        public DriverManager(string downloadDirectory):this()
+        public DriverManager(string downloadDirectory)
         {
             _downloadDirectory = downloadDirectory;
         }

--- a/WebDriverManager/DriverManager.cs
+++ b/WebDriverManager/DriverManager.cs
@@ -14,13 +14,12 @@ namespace WebDriverManager
 
         private IBinaryService _binaryService;
         private readonly IVariableService _variableService;
-        private string _downloadDirectory;
+        private string _downloadDirectory = Directory.GetCurrentDirectory();
 
         public DriverManager()
         {
             _binaryService = new BinaryService();
             _variableService = new VariableService();
-            _downloadDirectory = Directory.GetCurrentDirectory();
         }
 
         public DriverManager(string downloadDirectory)

--- a/WebDriverManager/DriverManager.cs
+++ b/WebDriverManager/DriverManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net;
 using WebDriverManager.DriverConfigs;
 using WebDriverManager.Helpers;
@@ -13,11 +14,17 @@ namespace WebDriverManager
 
         private IBinaryService _binaryService;
         private readonly IVariableService _variableService;
+        private string _downloadDirectory = Directory.GetCurrentDirectory();
 
         public DriverManager()
         {
             _binaryService = new BinaryService();
             _variableService = new VariableService();
+        }
+
+        public DriverManager(string downloadDirectory):this()
+        {
+            _downloadDirectory = downloadDirectory;
         }
 
         public DriverManager(IBinaryService binaryService, IVariableService variableService)
@@ -61,8 +68,7 @@ namespace WebDriverManager
                 version = GetVersionToDownload(config, version);
                 var url = architecture.Equals(Architecture.X32) ? config.GetUrl32() : config.GetUrl64();
                 url = UrlHelper.BuildUrl(url, version);
-                var binaryPath = FileHelper.GetBinDestination(config.GetName(), version, architecture,
-                    config.GetBinaryName());
+                var binaryPath = Path.Combine(_downloadDirectory, config.GetName(), version, architecture.ToString(), config.GetBinaryName());
                 return SetUpDriverImpl(url, binaryPath);
             }
         }


### PR DESCRIPTION
Adds a new constructor for DriverManager that takes a path where the drivers should be downloaded to. 
Current directory remains the default. Addresses #167.