### PR TITLE
Create proxy based on environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ new DriverManager().SetUpDriver(new TaobaoPhantomConfig());
 new DriverManager().WithProxy(previouslyInitializedProxy).SetUpDriver(new ChromeConfig());
 ```
 
+You can also set the environment variables `HTTP_PROXY` and/or `HTTPS_PROXY` to use a proxy when retrieving the drivers. 
+This does not require any changes in the setup of DriverManager in C#.
+
 ## Thanks
 Thanks to the following companies for generously providing their services/products to help improve this project:
 

--- a/WebDriverManager.Tests/BinaryServiceTests.cs
+++ b/WebDriverManager.Tests/BinaryServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using WebDriverManager.Helpers;
 using WebDriverManager.Services.Impl;
@@ -7,6 +8,38 @@ namespace WebDriverManager.Tests
 {
     public class BinaryServiceTests : BinaryService
     {
+        [Fact]
+        public void ProxySetBySystemVariableHttp()
+        {
+            const string url = "https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip";
+            const string httpName = "HTTP_PROXY";
+            const string proxyUrl = "http://myproxy:8080/";
+            Environment.SetEnvironmentVariable(httpName, proxyUrl);
+            CheckProxySystemVariables();
+            Assert.NotNull(Proxy);
+            Assert.Equal(proxyUrl, Proxy.GetProxy(new Uri(url)).AbsoluteUri);
+        }
+
+        [Fact]
+        public void ProxySetBySystemVariableHttps()
+        {
+            const string url = "https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip";
+            const string httpName = "HTTPS_PROXY";
+            const string proxyUrl = "http://myproxy:8080/";
+            Environment.SetEnvironmentVariable(httpName, proxyUrl);
+            CheckProxySystemVariables();
+            Assert.NotNull(Proxy);
+            Assert.Equal(proxyUrl, Proxy.GetProxy(new Uri(url)).AbsoluteUri);
+        }
+
+
+        [Fact]
+        public void NoProxyBySystemVariable()
+        {
+            CheckProxySystemVariables();
+            Assert.Null(Proxy);
+        }
+
         [Fact]
         public void DownloadZipResultNotEmpty()
         {

--- a/WebDriverManager.Tests/BinaryServiceTests.cs
+++ b/WebDriverManager.Tests/BinaryServiceTests.cs
@@ -16,6 +16,8 @@ namespace WebDriverManager.Tests
             const string proxyUrl = "http://myproxy:8080/";
             Environment.SetEnvironmentVariable(httpName, proxyUrl);
             CheckProxySystemVariables();
+            // Remove to make sure it is not saved in later runs
+            Environment.SetEnvironmentVariable(httpName, null);
             Assert.NotNull(Proxy);
             Assert.Equal(proxyUrl, Proxy.GetProxy(new Uri(url)).AbsoluteUri);
         }
@@ -25,9 +27,11 @@ namespace WebDriverManager.Tests
         {
             const string url = "https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip";
             const string httpName = "HTTPS_PROXY";
-            const string proxyUrl = "http://myproxy:8080/";
+            const string proxyUrl = "https://myproxy:8080/";
             Environment.SetEnvironmentVariable(httpName, proxyUrl);
             CheckProxySystemVariables();
+            // Remove to make sure it is not saved in later runs
+            Environment.SetEnvironmentVariable(httpName, null);
             Assert.NotNull(Proxy);
             Assert.Equal(proxyUrl, Proxy.GetProxy(new Uri(url)).AbsoluteUri);
         }

--- a/WebDriverManager/Services/Impl/BinaryService.cs
+++ b/WebDriverManager/Services/Impl/BinaryService.cs
@@ -163,11 +163,11 @@ namespace WebDriverManager.Services.Impl
             const string nameHttps = "HTTPS_PROXY";
             var httpProxyVariable = Environment.GetEnvironmentVariable(nameHttp, EnvironmentVariableTarget.Process);
             var httpsProxyVariable = Environment.GetEnvironmentVariable(nameHttps, EnvironmentVariableTarget.Process);
-            if (httpProxyVariable != null)
+            if (!string.IsNullOrEmpty(httpProxyVariable))
             {
                 Proxy = new WebProxy(httpProxyVariable);
             }
-            else if (httpsProxyVariable != null)
+            else if (!string.IsNullOrEmpty(httpsProxyVariable))
             {
                 Proxy = new WebProxy(httpsProxyVariable);
             }

--- a/WebDriverManager/Services/Impl/BinaryService.cs
+++ b/WebDriverManager/Services/Impl/BinaryService.cs
@@ -138,6 +138,8 @@ namespace WebDriverManager.Services.Impl
         public string DownloadZip(string url, string destination)
         {
             if (File.Exists(destination)) return destination;
+            if (Proxy == null) CheckProxySystemVariables();
+
             if (Proxy != null)
             {
                 using (var webClient = new WebClient() {Proxy = Proxy})
@@ -154,6 +156,21 @@ namespace WebDriverManager.Services.Impl
             }
 
             return destination;
+        }
+        protected void CheckProxySystemVariables()
+        {
+            const string nameHttp = "HTTP_PROXY";
+            const string nameHttps = "HTTPS_PROXY";
+            var httpProxyVariable = Environment.GetEnvironmentVariable(nameHttp, EnvironmentVariableTarget.Process);
+            var httpsProxyVariable = Environment.GetEnvironmentVariable(nameHttps, EnvironmentVariableTarget.Process);
+            if (httpProxyVariable != null)
+            {
+                Proxy = new WebProxy(httpProxyVariable);
+            }
+            else if (httpsProxyVariable != null)
+            {
+                Proxy = new WebProxy(httpsProxyVariable);
+            }
         }
 
         protected string UnZip(string path, string destination, string name)


### PR DESCRIPTION
Use HTTP_PROXY / HTTPS_PROXY system variables to set the proxy instead of hardcoded during WebDriverManager initiation

Should solve issue #195 