### PR TITLE
Fix mac arm64 suffix

### DIFF
--- a/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
@@ -36,7 +36,7 @@ namespace WebDriverManager.DriverConfigs.Impl
             {
                 var architectureExtension =
                     RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.Arm64
-                        ? "arm64"
+                        ? "_arm64"
                         : "64";
                 return $"{BaseVersionPatternUrl}chromedriver_mac{architectureExtension}.zip";
             }


### PR DESCRIPTION
This fixes the new arm64 suffix for mac releases and closes #210 . Tested on an M1 Mac.

I see the change https://github.com/rosolko/WebDriverManager.Net/commit/c40bcf97cbbf495e9ff9e1d486fe006e5bb63500 is not yet released, so I've tested it locally.

- Actual: https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_macarm64.zip
- Expected: https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_mac_arm64.zip