### PR TITLE
Widened support for chromium version matching

### DIFF
--- a/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
@@ -109,7 +109,8 @@ namespace WebDriverManager.DriverConfigs.Impl
             {
                 return RegistryHelper.GetInstalledBrowserVersionLinux(
                     "google-chrome", "--product-version",
-                    "chromium", "--version");
+                    "chromium", "--version",
+                    "chromium-browser", "--version");
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Hey @rosolko just a small change to bring over another chromium based version command for Linux users. I noticed this whilst running `WebDriverManager.Net` within an alpine based docker image.

What this may do is address this open issue here too (#138). It may be worth revisiting if the exception still occurs after widening the supported version queries for chrome on Linux based systems.