### PR TITLE
Chrome is often named simply "chrome"

### DIFF
--- a/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
@@ -221,7 +221,8 @@ namespace WebDriverManager.DriverConfigs.Impl
                 return RegistryHelper.GetInstalledBrowserVersionLinux(
                     "google-chrome", "--product-version",
                     "chromium", "--version",
-                    "chromium-browser", "--version");
+                    "chromium-browser", "--version",
+                    "chrome", "--product-version");
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
For example, when installed from a ZIP auto-downloaded from Google.