### PR TITLE
Fixed #308, Unzipping of files and able to download ChromeDriver 64 b…

### DIFF
--- a/WebDriverManager.Tests/WebDriverManager.Tests.csproj
+++ b/WebDriverManager.Tests/WebDriverManager.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/WebDriverManager/Clients/ChromeForTestingClient.cs
+++ b/WebDriverManager/Clients/ChromeForTestingClient.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using WebDriverManager.Models.Chrome;
 
 namespace WebDriverManager.Clients
@@ -10,11 +10,7 @@ namespace WebDriverManager.Clients
     public static class ChromeForTestingClient
     {
         private static readonly string BaseUrl = "https://googlechromelabs.github.io/chrome-for-testing/";
-        private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        };
-
+        
         private static HttpClient _httpClient;
 
         private static HttpClient HttpClient
@@ -67,7 +63,7 @@ namespace WebDriverManager.Clients
             var readStringTask = Task.Run(() => httpTask.Result.Content.ReadAsStringAsync());
             readStringTask.Wait();
 
-            return JsonSerializer.Deserialize<TResult>(readStringTask.Result, JsonSerializerOptions);
+            return JsonConvert.DeserializeObject<TResult>(readStringTask.Result);
         }
     }
 }

--- a/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
+++ b/WebDriverManager/DriverConfigs/Impl/ChromeConfig.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using WebDriverManager.Clients;
 using WebDriverManager.Helpers;
 using WebDriverManager.Models.Chrome;
+using Architecture = WebDriverManager.Helpers.Architecture;
 
 namespace WebDriverManager.DriverConfigs.Impl
 {
@@ -34,24 +35,24 @@ namespace WebDriverManager.DriverConfigs.Impl
 
         public virtual string GetUrl32()
         {
-            return GetUrl();
+            return GetUrl(Architecture.X32);
         }
 
         public virtual string GetUrl64()
         {
-            return GetUrl();
+            return GetUrl(Architecture.X64);
         }
 
-        private string GetUrl()
+        private string GetUrl(Architecture architecture)
         {
             // Handle newer versions of chrome driver only being available for download via the Chrome for Testing API's
             // whilst retaining backwards compatibility for older versions of chrome/chrome driver.
             if (_chromeVersionInfo != null)
             {
-                return GetUrlFromChromeForTestingApi();
+                return GetUrlFromChromeForTestingApi(architecture);
             }
 
-            return GetUrlFromChromeStorage();
+            return GetUrlFromChromeStorage(architecture);
         }
 
         public virtual string GetBinaryName()
@@ -131,7 +132,7 @@ namespace WebDriverManager.DriverConfigs.Impl
         /// Retrieves a download URL for a chrome driver from the https://chromedriver.storage.googleapis.com API's
         /// </summary>
         /// <returns>A chrome driver download URL</returns>
-        private string GetUrlFromChromeStorage()
+        private string GetUrlFromChromeStorage(Architecture architecture)
         {
 #if NETSTANDARD
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -155,8 +156,8 @@ namespace WebDriverManager.DriverConfigs.Impl
                 return $"{BaseVersionPatternUrl}chromedriver_linux64.zip";
             }
 #endif
-
-            return $"{BaseVersionPatternUrl}chromedriver_win32.zip";
+            var driverName = architecture == Architecture.X32 ? "chromedriver_win32.zip" : "chromedriver_win64.zip";
+            return $"{BaseVersionPatternUrl}{driverName}";
         }
 
         /// <summary>
@@ -180,9 +181,9 @@ namespace WebDriverManager.DriverConfigs.Impl
         /// Retrieves a chrome driver download URL from Chrome for Testing API's
         /// </summary>
         /// <returns>A chrome driver download URL</returns>
-        private string GetUrlFromChromeForTestingApi()
+        private string GetUrlFromChromeForTestingApi(Architecture architecture)
         {
-            var platform = "win32";
+            string platform = architecture == Architecture.X32 ? "win32" : "win64";
 
 #if NETSTANDARD
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/WebDriverManager/WebDriverManager.csproj
+++ b/WebDriverManager/WebDriverManager.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net472;netstandard2.0;netstandard2.1</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>2.17.1</Version>
         <Title>WebDriverManager.Net</Title>
@@ -20,8 +20,8 @@
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.1.0" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="SharpZipLib" Version="1.4.2" />
-        <PackageReference Include="System.Text.Json" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
@@ -30,5 +30,9 @@
 
     <ItemGroup>
         <None Include="..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="System.Net.Http" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
…it version.

#308 - Fixed by replacing json library with newtonsoft.json. 
Now downloads chromedriver 64 bit version as never downloaded this version only 32 bit. 
Fixed unzip issue with dealing with folder names in the zip file.

Updated to .net framework 4.7.2 as 4.6.2 is no longer supported.