### PR TITLE
Download ChromeDriver MatchingBrowser version network error

### DIFF
--- a/WebDriverManager.Tests/ChromeConfigTests.cs
+++ b/WebDriverManager.Tests/ChromeConfigTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using WebDriverManager.DriverConfigs.Impl;
+using WebDriverManager.Helpers;
 using Xunit;
 
 namespace WebDriverManager.Tests
@@ -19,6 +20,14 @@ namespace WebDriverManager.Tests
         public void DriverDownloadLatestTest()
         {
             new DriverManager().SetUpDriver(new ChromeConfig());
+            Assert.NotEmpty(WebDriverFinder.FindFile(GetBinaryName()));
+        }
+
+        [Fact]
+        public void DriverDownloadTest()
+        {
+            new DriverManager().SetUpDriver(new ChromeConfig(), VersionResolveStrategy.MatchingBrowser);
+
             Assert.NotEmpty(WebDriverFinder.FindFile(GetBinaryName()));
         }
     }

--- a/WebDriverManager/Clients/ChromeForTestingClient.cs
+++ b/WebDriverManager/Clients/ChromeForTestingClient.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using WebDriverManager.Helpers;
 using WebDriverManager.Models.Chrome;
 
 namespace WebDriverManager.Clients
@@ -10,7 +13,7 @@ namespace WebDriverManager.Clients
     public static class ChromeForTestingClient
     {
         private static readonly string BaseUrl = "https://googlechromelabs.github.io/chrome-for-testing/";
-        
+
         private static HttpClient _httpClient;
 
         private static HttpClient HttpClient
@@ -28,6 +31,10 @@ namespace WebDriverManager.Clients
                     BaseAddress = new Uri(BaseUrl)
                 };
 
+                _httpClient.DefaultRequestHeaders.Add("User-Agent", "WebDriverManager.NET");
+                _httpClient.DefaultRequestHeaders.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
+                _httpClient.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br, zstd");
+                _httpClient.DefaultRequestHeaders.Add("Accept-Language", "zh-CN,zh;q=0.9");
                 return _httpClient;
             }
         }
@@ -59,11 +66,26 @@ namespace WebDriverManager.Clients
         {
             var httpTask = Task.Run(() => taskToRun);
             httpTask.Wait();
+            var response = httpTask.Result;
+            if (response.Content.Headers.Contains("Content-Encoding"))
+            {
+                string encoding = response.Content.Headers.GetValues("Content-Encoding").FirstOrDefault();
+                if (string.Equals(encoding, "gzip", StringComparison.OrdinalIgnoreCase))
+                {
+                    var readBytesTask = Task.Run(() => httpTask.Result.Content.ReadAsByteArrayAsync());
+                    readBytesTask.Wait();
+
+                    byte[] decompressionData = GzipDecompression.DecompressGzip(readBytesTask.Result);
+                    return JsonConvert.DeserializeObject<TResult>(Encoding.UTF8.GetString(decompressionData));
+                }
+            }
+
 
             var readStringTask = Task.Run(() => httpTask.Result.Content.ReadAsStringAsync());
             readStringTask.Wait();
-
             return JsonConvert.DeserializeObject<TResult>(readStringTask.Result);
+
+
         }
     }
 }

--- a/WebDriverManager/Helpers/GzipDecompression.cs
+++ b/WebDriverManager/Helpers/GzipDecompression.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebDriverManager.Helpers
+{
+    internal class GzipDecompression
+    {
+        public static byte[] DecompressGzip(byte[] compressedData)
+        {
+            using (MemoryStream compressedStream = new MemoryStream(compressedData))
+            using (MemoryStream decompressedStream = new MemoryStream())
+            {
+                using (GZipStream decompressionStream = new GZipStream(compressedStream, CompressionMode.Decompress))
+                {
+                    decompressionStream.CopyTo(decompressedStream);
+                }
+
+                return decompressedStream.ToArray();
+            }
+        }
+    }
+}


### PR DESCRIPTION
My area is in China，In use 
`new DriverManager().SetUpDriver(new ChromeConfig(), VersionResolveStrategy.MatchingBrowser);` 
a network error will occur.
So I used postman to test the download json link in the code "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json", and found that if the User-Agent, Accept, and Accept-Encoding request headers are added, it takes about a few hundred milliseconds to get the json. If the request headers are not added, it takes about 2-3 minutes, or even longer, or HttpClient will throw a Cancel Task exception.
![微信图片_20240619145337](https://github.com/rosolko/WebDriverManager.Net/assets/43633587/6a3a70fa-b63a-4735-ab86-53373a1eccdf)
![微信图片_20240619145343](https://github.com/rosolko/WebDriverManager.Net/assets/43633587/9bd21f2c-d50f-487f-ac22-0b257d6c9632)
