### PR TITLE
Security: upgrade AngleSharp for GHSA-pgww-w46g-26qg

### DIFF
--- a/WebDriverManager/WebDriverManager.csproj
+++ b/WebDriverManager/WebDriverManager.csproj
@@ -18,10 +18,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.1.2" />
+        <PackageReference Include="AngleSharp" Version="1.5.2" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="SharpZipLib" Version="1.4.2" />
+        <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
This PR upgrades AngleSharp to address GitHub advisory GHSA-pgww-w46g-26qg which is a moderate-severity issue related to HTML5 parsing/spec compliance and potential mXSS sanitizer bypass behavior.

**Advisory details:**
Package: AngleSharp (NuGet)
Affected versions: < 1.5.0
Patched versions: >= 1.5.0
Advisory: https://github.com/advisories/GHSA-pgww-w46g-26qg

### What changed
- Upgraded `AngleSharp` to version `1.5.2`
- Added an explicit package reference to `System.Text.Encoding.CodePages`

### Why the explicit System.Text.Encoding.CodePages reference is needed
After upgrading `AngleSharp`, tests that parse HTML started failing at runtime with:

_FileNotFoundException for System.Text.Encoding.CodePages, Version=8.0.0.0_

Adding an explicit `System.Text.Encoding.CodePages` reference ensures the assembly is resolved consistently during test/runtime execution for the project’s target frameworks.

### Validation
Executed test suite:

`dotnet test WebDriverManager.Tests.csproj -v minimal`

Result:
- Total: 74
- Failed: 0
- Passed: 66
- Skipped: 8 (existing explicit skips)